### PR TITLE
Update README to show url in Webpage constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ print("Embedding:", embeddings)
 
 Or if you have the HTML document already downloaded:
 ```python
-website = Webpage()
+website = Webpage("<url>")
 website.html = "..."
-website.url = "..."
 website.screenshot_path = "..." # optional
 scores, embeddings = model.predict(website)
 ```


### PR DESCRIPTION
The current demo code throws with `TypeError: Webpage.__init__() missing 1 required positional argument: 'url'`